### PR TITLE
fix: datasets output path to data

### DIFF
--- a/datasets/imdb.sh
+++ b/datasets/imdb.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-SCRIPT_VERSION="0.0.0"
+SCRIPT_VERSION="0.0.1"
 DATASETS_FILES=(
   "name.basics.tsv"
   "title.akas.tsv"
@@ -11,9 +11,9 @@ DATASETS_FILES=(
   "title.ratings.tsv"
 )
 DATASETS_BASE_URL="https://datasets.imdbws.com/"
+OUTPUT_HDFS_DIRNAME="data/imdb"
 
 username="tdp_user"
-output_hdfs_dirname="imdb"
 
 # Options followed by a colon have a required argument
 shortopts="u:hV"
@@ -22,7 +22,7 @@ longopts="username:,help,version"
 print_usage()
 {
   echo "Download IMDb datasets."
-  echo "File are stored in TSV format at /user/{username}/${output_hdfs_dirname}/{table_name}.tsv."
+  echo "File are stored in TSV format at /user/{username}/${OUTPUT_HDFS_DIRNAME}/{table_name}.tsv."
   echo "The complete dataset is approximately 5.5GB."
   echo
   echo "Usage: imdb.sh [OPTION...]"
@@ -68,7 +68,7 @@ do
 done
 
 # Create HDFS folder if doesn't exist
-output_hdfs_path="/user/${username}/${output_hdfs_dirname}"
+output_hdfs_path="/user/${username}/${OUTPUT_HDFS_DIRNAME}"
 hdfs dfs -mkdir -p ${output_hdfs_path}
 
 # Download the dataset to HDFS, overwrite if exists

--- a/datasets/nyc-green-taxi-trip.sh
+++ b/datasets/nyc-green-taxi-trip.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-SCRIPT_VERSION="0.0.0"
+SCRIPT_VERSION="0.0.1"
 DATASET_BASE_URL="https://d37ci6vzurychx.cloudfront.net/trip-data/"
 DATASET_MIN_YEAR=2013
 DATASET_MAX_YEAR=2021
+OUTPUT_HDFS_DIRNAME="data/nyc_green_taxi_trip"
 
 username="tdp_user"
-output_hdfs_dirname="nyc_green_taxi_trip"
 from="01-2013"
 to="12-2021"
 
@@ -17,7 +17,7 @@ longopts="from:,to:,username:,version,help"
 print_usage()
 {
   echo "Download the NYC Green Taxi Trip datasets."
-  echo "Files are stored in the Parquet format in /user/{username}/${output_hdfs_dirname}/{year}/green_tripdata_{year}-{month}.parquet."
+  echo "Files are stored in the Parquet format in /user/{username}/${OUTPUT_HDFS_DIRNAME}/{year}/green_tripdata_{year}-{month}.parquet."
   echo "The full dataset is 1.2GB."
   echo
   echo "Usage: nyc-green-taxi-trip.sh [OPTION...]"
@@ -159,7 +159,7 @@ do
   file_name="green_tripdata_${date}.parquet"
   file_url="${DATASET_BASE_URL}${file_name}"
   IFS=- read -r year month <<< $date
-  output_hdfs_path="/user/${username}/${output_hdfs_dirname}/${year}"
+  output_hdfs_path="/user/${username}/${OUTPUT_HDFS_DIRNAME}/${year}"
   hdfs dfs -mkdir -p ${output_hdfs_path}
   echo "Downloading $file_url to ${output_hdfs_path}/${file_name}"
   curl "$file_url" | hdfs dfs -put -f - ${output_hdfs_path}/${file_name}


### PR DESCRIPTION
- Set the output path for downloaded datasets in HDFS from `/user/{username}/{dataset}` to `/user/{username}/data/{dataset}`.
- Rename the `output_hdfs_dirname` var to `OUTPUT_HDFS_DIRNAME`, to highlight it as a read-only variable.
- Increment script version from `0.0.0` to `0.0.1`.