### PR TITLE
fix:removed an extra space in the definition of target causing download problems

### DIFF
--- a/datasets/imdb.sh
+++ b/datasets/imdb.sh
@@ -67,7 +67,7 @@ do
   esac
   shift
 done
-target=${target:-${IMDB_TARGET_DIRECTORY} }
+target=${target:-${IMDB_TARGET_DIRECTORY}}
 
 # Create HDFS folder if doesn't exist
 hdfs dfs -mkdir -p ${target}


### PR DESCRIPTION
Line 70 of the file imdb.sh a space was present and made the download path unusable. In fact by following the alliage tutorial the download path was not found. By removing this extra space in the path the download should be done without problem.